### PR TITLE
(part 1) Feat-17: check for latestBlockHeight to determine validators cache

### DIFF
--- a/app/src/services/rpc-client.ts
+++ b/app/src/services/rpc-client.ts
@@ -157,15 +157,18 @@ export class RpcClient {
       "processedValidatorsWithStatus"
     );
 
-    if (cachedValidatorsInfo) {
+    const {
+      header: { era_id: latestEraId },
+    } = await this.getLatestBlock();
+
+    if (
+      cachedValidatorsInfo &&
+      latestEraId === cachedValidatorsInfo.status.latestEraId
+    ) {
       return paginateValidators(cachedValidatorsInfo, count, pageNum);
     }
 
     const validatorsInfo = await this.rpcClient.getValidatorsInfo();
-
-    const {
-      header: { era_id: latestEraId },
-    } = await this.getLatestBlock();
 
     const processedValidatorsWithStatus = processValidatorsInfoResult(
       validatorsInfo,
@@ -187,15 +190,22 @@ export class RpcClient {
       "processedValidatorsWithStatus"
     );
 
-    if (cachedValidatorsInfo) {
+    const {
+      header: { era_id: latestEraId },
+    } = await this.getLatestBlock();
+
+    if (
+      cachedValidatorsInfo &&
+      latestEraId === cachedValidatorsInfo.status.latestEraId
+    ) {
       currentValidatorsInfo = cachedValidatorsInfo;
     } else {
       currentValidatorsInfo = await this.getCurrentEraValidators();
     }
 
     return {
-      validatorsCount: currentValidatorsInfo.status.activeValidatorsCount,
-      bidsCount: currentValidatorsInfo.status.activeBidsCount,
+      validatorsCount: currentValidatorsInfo.status.validatorsCount,
+      bidsCount: currentValidatorsInfo.status.bidsCount,
     };
   }
 }

--- a/app/src/services/utils.ts
+++ b/app/src/services/utils.ts
@@ -82,8 +82,9 @@ export const processValidatorsInfoResult = (
   return {
     validators: processedValidators,
     status: {
-      activeValidatorsCount: activeValidators.length,
-      activeBidsCount: activeBids.length,
+      validatorsCount: activeValidators.length,
+      bidsCount: activeBids.length,
+      latestEraId,
     },
   };
 };

--- a/app/src/types/on-chain.ts
+++ b/app/src/types/on-chain.ts
@@ -76,7 +76,8 @@ export interface ValidatorProcessed {
 export interface ValidatorsProcessedWithStatus {
   validators: ValidatorProcessed[];
   status: {
-    activeValidatorsCount: number;
-    activeBidsCount: number;
+    validatorsCount: number;
+    bidsCount: number;
+    latestEraId: number;
   };
 }


### PR DESCRIPTION
### 🔥 Summary
- Use `currentBlockHeight` and `era` to determine if validators cache should be used.

### 😤 Problem / Goals
- Right now, we are always using validators cache even when `era` is in past.

### 🤓 Solution
- Check to see if the latest `era` matches the currently cached value to see if we need to fetch updated validators data.

### 🗒️ Additional Notes
- This is part 1 of 2 for this ticket: https://github.com/casper-network/casper-blockexplorer-middleware/issues/17. A more extensive approach to caching validators will be taken in part 2, but this is a quick fix that works quite well for the time being.
