### PR TITLE
bugfix-28: filter by all bids for processed validators info

### DIFF
--- a/app/src/services/utils.ts
+++ b/app/src/services/utils.ts
@@ -1,6 +1,6 @@
 import { ValidatorsInfoResult } from "casper-js-sdk";
-import { Peer, Sort } from "../types";
 
+import { Peer, Sort } from "../types";
 import {
   ValidatorProcessed,
   ValidatorsProcessedWithStatus,


### PR DESCRIPTION
### 🔥 Summary
- Update processing validators info for table to match validators with all bids, as opposed to just active ones. https://github.com/casper-network/casper-blockexplorer-middleware/issues/28

### 😤 Problem / Goals
- Occasionally active validators don't have an associated active bid but we still want to be able to display this information on the validators table.

### 🤓 Solution
- Match active validators with all bids, not just active ones.

### 🗒️ Additional Notes
-
