### PR TITLE
feat-47: add strict eslint rules

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,0 +1,27 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "simple-import-sort", "unused-imports"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "@typescript-eslint/ban-ts-comment": "off"
+  }
+}


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-middleware/issues/47: adding `.eslintrc` file with stricter eslint rules.

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
