### PR TITLE
feat-391(FE): process latest deploy before emitting to client

### DIFF
--- a/app/src/deploys/deploys.service.ts
+++ b/app/src/deploys/deploys.service.ts
@@ -41,7 +41,13 @@ export class DeploysService {
     if (!cachedDeploy) {
       await this.cacheManager.set(latestDeploy.deploy_hash, latestDeploy);
 
-      this.gateway.handleEvent("latest_deploy", { latestDeploy });
+      const [processedLatestDeploy] = getProcessedSidecarDeploys([
+        latestDeploy,
+      ]);
+
+      this.gateway.handleEvent("latest_deploy", {
+        latestDeploy: processedLatestDeploy,
+      });
     }
   }
 


### PR DESCRIPTION
### 🔥 Summary
Corresponding to: https://github.com/casper-network/casper-blockexplorer-frontend/compare/epic/379/deploys-table-using-sidecar...feat/391/websocket-listener-deploys-table?expand=1

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
